### PR TITLE
feat: adapt scripts for L2 deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Compiler files
 cache/
 out/
+zkout/
 
 # Ignores development broadcast logs
 !/broadcast

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -1,4 +1,4 @@
-export NETWORK=${NETWORK:-"L2"}
+export NETWORK=${NETWORK:-"ERA"}
 
 export RPC_URL=${RPC_URL:-"http://127.0.0.1:8545"}
 export PRIVATE_KEY=${PRIVATE_KEY:-"0x0000000000000000000000000000000000000000000000000000000000000000"}
@@ -22,16 +22,16 @@ echo "USDC_ADDRESS: $USDC_ADDRESS"
 echo "PROOF_MANAGER_OWNER_ADDRESS: $PROOF_MANAGER_OWNER_ADDRESS"
 echo "PROXY_OWNER_ADDRESS: $PROXY_OWNER_ADDRESS"
 
-if [ "$NETWORK" == "L2" ]; then
+if [ "$NETWORK" == "ERA" ]; then
     forge build --zksync
-elif [ "$NETWORK" == "L1" ]; then
+elif [ "$NETWORK" == "ETH" ]; then
     forge build
 else
-    echo "Invalid network, expected L1 or L2, got: $NETWORK"
+    echo "Invalid network, expected ERA or ETH, got: $NETWORK"
     exit 1
 fi
 
-if [ "$NETWORK" == "L2" ]; then
+if [ "$NETWORK" == "ERA" ]; then
     forge script --zksync scripts/deployment/DeployProofManagerV1.s.sol \
         --broadcast \
         --rpc-url $RPC_URL \
@@ -39,7 +39,7 @@ if [ "$NETWORK" == "L2" ]; then
         --with-gas-price $GAS_PRICE \
         --slow \
         -vvvv
-elif [ "$NETWORK" == "L1" ]; then
+elif [ "$NETWORK" == "ETH" ]; then
     forge script scripts/deployment/DeployProofManagerV1.s.sol \
         --broadcast \
         --rpc-url $RPC_URL \
@@ -47,6 +47,6 @@ elif [ "$NETWORK" == "L1" ]; then
         --with-gas-price $GAS_PRICE \
         -vvvv
 else
-    echo "Invalid network, expected L1 or L2, got: $NETWORK"
+    echo "Invalid network, expected ERA or ETH, got: $NETWORK"
     exit 1
 fi

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -1,3 +1,5 @@
+export NETWORK=${NETWORK:-"L2"}
+
 export RPC_URL=${RPC_URL:-"http://127.0.0.1:8545"}
 export PRIVATE_KEY=${PRIVATE_KEY:-"0x0000000000000000000000000000000000000000000000000000000000000000"}
 export ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY:-"0000000000000000000000000000000000000000000000000000000000000000"}
@@ -6,8 +8,6 @@ export LAGRANGE_ADDRESS=${LAGRANGE_ADDRESS:-"0x000000000000000000000000000000000
 export USDC_ADDRESS=${USDC_ADDRESS:-"0x0000000000000000000000000000000000000001"}
 export PROOF_MANAGER_OWNER_ADDRESS=${PROOF_MANAGER_OWNER_ADDRESS:-"0x0000000000000000000000000000000000000001"}
 export PROXY_OWNER_ADDRESS=${PROXY_OWNER_ADDRESS:-"0x0000000000000000000000000000000000000001"}
-
-forge build
 
 export GAS_PRICE=$(cast gas-price --rpc-url $RPC_URL)
 
@@ -22,9 +22,31 @@ echo "USDC_ADDRESS: $USDC_ADDRESS"
 echo "PROOF_MANAGER_OWNER_ADDRESS: $PROOF_MANAGER_OWNER_ADDRESS"
 echo "PROXY_OWNER_ADDRESS: $PROXY_OWNER_ADDRESS"
 
-forge script scripts/deployment/DeployProofManagerV1.s.sol \
-    --broadcast \
-    --rpc-url $RPC_URL \
-    --private-key $PRIVATE_KEY \
-    --with-gas-price $GAS_PRICE \
-    -vvvv
+if [ "$NETWORK" == "L2" ]; then
+    forge build --zksync
+elif [ "$NETWORK" == "L1" ]; then
+    forge build
+else
+    echo "Invalid network, expected L1 or L2, got: $NETWORK"
+    exit 1
+fi
+
+if [ "$NETWORK" == "L2" ]; then
+    forge script --zksync scripts/deployment/DeployProofManagerV1.s.sol \
+        --broadcast \
+        --rpc-url $RPC_URL \
+        --private-key $PRIVATE_KEY \
+        --with-gas-price $GAS_PRICE \
+        --slow \
+        -vvvv
+elif [ "$NETWORK" == "L1" ]; then
+    forge script scripts/deployment/DeployProofManagerV1.s.sol \
+        --broadcast \
+        --rpc-url $RPC_URL \
+        --private-key $PRIVATE_KEY \
+        --with-gas-price $GAS_PRICE \
+        -vvvv
+else
+    echo "Invalid network, expected L1 or L2, got: $NETWORK"
+    exit 1
+fi


### PR DESCRIPTION
# What ❔

Adapt deployment scripts for deployment on L2.
Now you can provide variable NETWORK, which can be equal ETH or ERA and script will behave correspondingly

## Why ❔

Overall contracts should be deployed on L2

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
