### PR TITLE
feat: additionally emit request Id of proof request

### DIFF
--- a/src/ProofManagerV1.sol
+++ b/src/ProofManagerV1.sol
@@ -165,7 +165,8 @@ contract ProofManagerV1 is IProofManager, Initializable, OwnableUpgradeable, Pro
             status: status,
             assignedTo: assignedTo,
             requestedReward: 0,
-            proof: bytes("")
+            proof: bytes(""),
+            requestId: _requestCounter
         });
 
         emit ProofRequestSubmitted(
@@ -177,7 +178,8 @@ contract ProofManagerV1 is IProofManager, Initializable, OwnableUpgradeable, Pro
             params.protocolMinor,
             params.protocolPatch,
             params.timeoutAfter,
-            params.maxReward
+            params.maxReward,
+            _requestCounter
         );
 
         // overflow is not a problem here, the number of proofs is unfathomably large (we'd need some ~10**66 proofs per second for 100 years straight for overflow to happen)

--- a/src/interfaces/IProofManager.sol
+++ b/src/interfaces/IProofManager.sol
@@ -90,6 +90,7 @@ interface IProofManager {
         uint256 maxReward;
         uint256 requestedReward;
         bytes proof;
+        uint256 requestId;
     }
 
     /*//////////////////////////////////////////
@@ -106,7 +107,8 @@ interface IProofManager {
         uint32 protocolMinor,
         uint32 protocolPatch,
         uint256 timeoutAfter,
-        uint256 maxReward
+        uint256 maxReward,
+        uint256 requestId
     );
 
     /// @dev Emitted when a proof request validation result is submitted.

--- a/test/ProofManagerV1.t.sol
+++ b/test/ProofManagerV1.t.sol
@@ -1046,7 +1046,11 @@ contract ProofManagerV1Test is Test {
             "Proving network requested reward should be set correctly"
         );
         assertEq(proofRequest.proof, expectedProofRequest.proof, "Proof should be set correctly");
-        assertEq(proofRequest.requestId, expectedProofRequest.requestId, "Request ID should be set correctly");
+        assertEq(
+            proofRequest.requestId,
+            expectedProofRequest.requestId,
+            "Request ID should be set correctly"
+        );
     }
 
     /*//////////////////////////////////////////

--- a/test/ProofManagerV1.t.sol
+++ b/test/ProofManagerV1.t.sol
@@ -264,7 +264,8 @@ contract ProofManagerV1Test is Test {
             27,
             0,
             3600,
-            4e6
+            4e6,
+            0
         );
 
         vm.prank(owner);
@@ -284,7 +285,8 @@ contract ProofManagerV1Test is Test {
                 status: IProofManager.ProofRequestStatus.PendingAcknowledgement,
                 assignedTo: IProofManager.ProvingNetwork.Fermah,
                 requestedReward: 0,
-                proof: bytes("")
+                proof: bytes(""),
+                requestId: 0
             })
         );
     }
@@ -408,7 +410,8 @@ contract ProofManagerV1Test is Test {
                     status: outputs[i].status,
                     assignedTo: outputs[i].network,
                     requestedReward: 0,
-                    proof: bytes("")
+                    proof: bytes(""),
+                    requestId: i
                 })
             );
         }
@@ -444,7 +447,8 @@ contract ProofManagerV1Test is Test {
                 status: IProofManager.ProofRequestStatus.Validated,
                 assignedTo: IProofManager.ProvingNetwork.Fermah,
                 requestedReward: 0,
-                proof: bytes("")
+                proof: bytes(""),
+                requestId: 1
             })
         );
     }
@@ -558,7 +562,8 @@ contract ProofManagerV1Test is Test {
                 status: IProofManager.ProofRequestStatus.ValidationFailed,
                 assignedTo: IProofManager.ProvingNetwork.Fermah,
                 requestedReward: 0,
-                proof: bytes("")
+                proof: bytes(""),
+                requestId: 1
             })
         );
         assertProvingNetworkInfo(
@@ -1041,6 +1046,7 @@ contract ProofManagerV1Test is Test {
             "Proving network requested reward should be set correctly"
         );
         assertEq(proofRequest.proof, expectedProofRequest.proof, "Proof should be set correctly");
+        assertEq(proofRequest.requestId, expectedProofRequest.requestId, "Request ID should be set correctly");
     }
 
     /*//////////////////////////////////////////

--- a/test/ProofManagerV1.t.sol
+++ b/test/ProofManagerV1.t.sol
@@ -448,7 +448,7 @@ contract ProofManagerV1Test is Test {
                 assignedTo: IProofManager.ProvingNetwork.Fermah,
                 requestedReward: 0,
                 proof: bytes(""),
-                requestId: 1
+                requestId: 0
             })
         );
     }
@@ -563,7 +563,7 @@ contract ProofManagerV1Test is Test {
                 assignedTo: IProofManager.ProvingNetwork.Fermah,
                 requestedReward: 0,
                 proof: bytes(""),
-                requestId: 1
+                requestId: 0
             })
         );
         assertProvingNetworkInfo(


### PR DESCRIPTION
# What ❔

When getting info of proofRequest, additionally provide info about request's internal identifier

## Why ❔

For external parties to ensure they are not missing any events

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
