### PR TITLE
fix: heapObligations initialization

### DIFF
--- a/src/ProofManagerV1.sol
+++ b/src/ProofManagerV1.sol
@@ -147,8 +147,8 @@ contract ProofManagerV1 is
         for (uint256 i = 1; i <= n; i++) {
             MinHeapLib.Node memory node = _heap.nodeAt(i);
             obligations += _proofRequests[
-                node.proofRequestIdentifier.chainId
-            ][node.proofRequestIdentifier.blockNumber].maxReward;
+                    node.proofRequestIdentifier.chainId
+                ][node.proofRequestIdentifier.blockNumber].maxReward;
         }
         heapObligations = obligations;
     }

--- a/src/ProofManagerV1.sol
+++ b/src/ProofManagerV1.sol
@@ -125,6 +125,34 @@ contract ProofManagerV1 is
         _updateMaxReward(5_000_000);
     }
 
+    /// @dev Recovery migration for proxies that were upgraded to V2 while the heap was
+    ///      non-empty. `heapObligations` is a counter introduced together with V2, so the
+    ///      V2 upgrade left it at zero even though the heap inherited in-flight requests
+    ///      from V1. The first subsequent call that decrements `heapObligations` (the
+    ///      `_purge_expired_requests` loop inside `submitProofRequest`, the refused branch
+    ///      of `acknowledgeProofRequest`, or `submitProof`) then underflows with
+    ///      `Panic(0x11)`, bricking those code paths.
+    ///
+    ///      This routine walks every entry currently in the heap and sums the
+    ///      per-request `maxReward` to reconstruct the value `heapObligations` should
+    ///      have had immediately after the V2 upgrade. `reinitializer(3)` ensures it
+    ///      runs at most once on a given proxy.
+    ///
+    ///      Note: greenfield deployments will never have a non-empty heap before V3 is
+    ///      reached, so for those proxies this call is a harmless no-op that simply
+    ///      bumps the initialized version.
+    function initializeV3() external reinitializer(3) {
+        uint256 obligations = 0;
+        uint256 n = _heap.size();
+        for (uint256 i = 1; i <= n; i++) {
+            MinHeapLib.Node memory node = _heap.nodeAt(i);
+            obligations += _proofRequests[
+                node.proofRequestIdentifier.chainId
+            ][node.proofRequestIdentifier.blockNumber].maxReward;
+        }
+        heapObligations = obligations;
+    }
+
     /*////////////////////////
             Getters
     ////////////////////////*/

--- a/src/store/MinHeapLib.sol
+++ b/src/store/MinHeapLib.sol
@@ -56,6 +56,19 @@ library MinHeapLib {
         return heap.nodes[1];
     }
 
+    /// @notice Returns the i-th node in the heap, using 1-based indexing.
+    /// @dev Provided for one-shot migrations that must walk every entry currently
+    ///      in the heap (e.g. backfilling an aggregate counter that was added in
+    ///      a later upgrade). Heap order is *not* sorted order — callers that need
+    ///      to enumerate every entry can simply iterate i = 1..size() and read each
+    ///      node's `proofRequestIdentifier`, which is sufficient for aggregation.
+    /// @param heap The heap to query
+    /// @param i 1-based index in the range [1, size()]; passing 0 or out-of-range reverts.
+    function nodeAt(Heap storage heap, uint256 i) internal view returns (Node memory) {
+        require(i != 0 && i < heap.nodes.length, "Heap: idx OOB");
+        return heap.nodes[i];
+    }
+
     /// @notice Gets the heap index for a given proof request identifier
     /// @param heap The heap to query
     /// @param proofRequestIdentifier The proof request identifier to look up

--- a/test/ProofManagerV1.t.sol
+++ b/test/ProofManagerV1.t.sol
@@ -218,6 +218,144 @@ contract ProofManagerV1Test is Test {
     }
 
     /*//////////////////////////////////////////
+            1.III. V3 Recovery Migration
+    //////////////////////////////////////////*/
+
+    // The V2 upgrade introduced the `heapObligations` counter but left it at zero on
+    // proxies that already had in-flight requests in the heap, which caused
+    // `_purge_expired_requests` and the refused/proven branches to underflow with
+    // `Panic(0x11)` once any pre-existing entry got touched. The tests below cover
+    // `initializeV3`, the one-shot recovery routine that walks the live heap and
+    // rebuilds `heapObligations` so those code paths become safe again.
+
+    /// @dev Storage slot of the `heapObligations` field (slot index 8 per
+    ///      `forge inspect ProofManagerV1 storage-layout`). Used by the tests below
+    ///      to simulate the bug state on otherwise-correctly-tracked harness storage.
+    bytes32 private constant HEAP_OBLIGATIONS_SLOT = bytes32(uint256(8));
+
+    /// @dev With a populated heap, V3 must reconstruct `heapObligations` as the sum
+    ///      of `maxReward` over every entry currently in the heap. We populate the
+    ///      heap normally (so the harness tracks the correct value), then clobber the
+    ///      slot to zero to simulate the post-V2 bug, and finally assert that V3
+    ///      restores the value to what it was before clobbering.
+    function testInitializeV3_backfillsHeapObligations() public {
+        // Populate the heap with three requests of distinct maxRewards. Use distinct
+        // values so a wrong-attribution implementation (e.g. counting the same entry
+        // multiple times) would surface as a mismatched total. Set Fermah as the
+        // preferred network so every round-robin slot maps to an active provider —
+        // without this the third submission would be refused and would never enter
+        // the heap, making the expected sum smaller than intended.
+        vm.prank(owner);
+        proofManager.updatePreferredProvingNetwork(IProofManager.ProvingNetwork.Fermah);
+
+        uint256[3] memory rewards = [uint256(4_000_000), 3_000_000, 2_500_000];
+        uint256 expected = 0;
+        for (uint256 i = 0; i < rewards.length; i++) {
+            vm.prank(submitter);
+            proofManager.submitProofRequest(
+                IProofManager.ProofRequestIdentifier(1, i + 1),
+                IProofManager.ProofRequestParams({
+                    proofInputsUrl: "https://console.google.com/buckets/...",
+                    protocolMajor: 0,
+                    protocolMinor: 27,
+                    protocolPatch: 0,
+                    timeoutAfter: 3600,
+                    maxReward: rewards[i]
+                })
+            );
+            expected += rewards[i];
+        }
+        assertEq(
+            proofManager.getHeapObligations(),
+            expected,
+            "sanity: harness should track obligations correctly before clobbering"
+        );
+
+        // Simulate the post-V2 bug: counter zeroed out while the heap still holds entries.
+        vm.store(address(proofManager), HEAP_OBLIGATIONS_SLOT, bytes32(uint256(0)));
+        assertEq(proofManager.getHeapObligations(), 0, "clobber must take effect");
+
+        proofManager.initializeV3();
+
+        assertEq(
+            proofManager.getHeapObligations(),
+            expected,
+            "V3 must rebuild heapObligations as sum of in-flight maxRewards"
+        );
+    }
+
+    /// @dev End-to-end: in the bugged state, `submitProofRequest` reverts with
+    ///      `Panic(0x11)` once a pre-existing heap entry has expired and the purge
+    ///      loop tries to subtract from a zero counter. After running V3 the same
+    ///      submission succeeds, confirming the recovery actually unbricks the
+    ///      contract rather than just reshuffling internal state.
+    function testInitializeV3_unbricksSubmitAfterExpiry() public {
+        submitDefaultProofRequest(1, 1);
+
+        // Reproduce the bug: counter at zero while the heap still holds the entry above.
+        vm.store(address(proofManager), HEAP_OBLIGATIONS_SLOT, bytes32(uint256(0)));
+
+        // ACK_TIMEOUT is 2 minutes; warping past it means the entry is expired and the
+        // next `submitProofRequest` will hit `_purge_expired_requests`.
+        vm.warp(block.timestamp + 3 minutes);
+
+        vm.expectRevert(stdError.arithmeticError);
+        vm.prank(submitter);
+        proofManager.submitProofRequest(
+            IProofManager.ProofRequestIdentifier(1, 2), defaultProofRequestParams()
+        );
+
+        // Recovery: rebuild the counter, then the same submission should now succeed.
+        proofManager.initializeV3();
+
+        vm.prank(submitter);
+        proofManager.submitProofRequest(
+            IProofManager.ProofRequestIdentifier(1, 2), defaultProofRequestParams()
+        );
+    }
+
+    /// @dev V3 only counts entries that are *currently* in the heap. Requests that
+    ///      have left the heap (proven, refused, expired-and-purged) must not be
+    ///      double-counted, otherwise the rebuilt value would over-state obligations
+    ///      and reduce capacity for new submissions.
+    function testInitializeV3_excludesEntriesAlreadyRemovedFromHeap() public {
+        // (1, 1): submit then prove — leaves the heap.
+        submitDefaultProofRequest(1, 1);
+        vm.prank(fermah);
+        proofManager.acknowledgeProofRequest(IProofManager.ProofRequestIdentifier(1, 1), true);
+        vm.prank(fermah);
+        proofManager.submitProof(
+            IProofManager.ProofRequestIdentifier(1, 1), bytes("proof"), 4_000_000
+        );
+
+        // (1, 2): submit and leave it pending — stays in the heap.
+        submitDefaultProofRequest(1, 2);
+
+        uint256 expected = 4_000_000; // only (1, 2) is still in the heap
+
+        // Clobber and recover.
+        vm.store(address(proofManager), HEAP_OBLIGATIONS_SLOT, bytes32(uint256(0)));
+        proofManager.initializeV3();
+
+        assertEq(
+            proofManager.getHeapObligations(),
+            expected,
+            "V3 must skip proof requests that have already been removed from the heap"
+        );
+    }
+
+    /// @dev `reinitializer(3)` must prevent replay. Re-running V3 — including via the
+    ///      same admin path that legitimately invokes it during the upgrade — has to
+    ///      revert, otherwise an attacker (or a misconfigured upgrade) could clobber
+    ///      heapObligations after the contract has resumed normal operation.
+    function testInitializeV3_cannotBeCalledTwice() public {
+        proofManager.initializeV3();
+
+        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+        proofManager.initializeV3();
+    }
+
+    /*//////////////////////////////////////////
         2. Proving Network Management
     //////////////////////////////////////////*/
 


### PR DESCRIPTION
# What ❔

Adds reinitializer that can recalculate heapObligations.
The test reproducing the bug is `testInitializeV3_unbricksSubmitAfterExpiry`

## Why ❔

In previous iteration, `heapObligations` wasn't initialized, which leads to arithmetic underflow on removing the request from heap.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
